### PR TITLE
MAIC201 according to 2023-24 syllabus

### DIFF
--- a/courses/MAIC201.md
+++ b/courses/MAIC201.md
@@ -18,10 +18,6 @@ specifics:
     semester: 3
     credits: [3, 0, 0, 3]
 
-  - branch: PI
-    semester: <semester>
-    credits: [<lecture>, <tutorial>, <practical>, <total>]
-
 prereq: []
 kind: EPR
 ---

--- a/courses/MAIC201.md
+++ b/courses/MAIC201.md
@@ -91,14 +91,11 @@ kind: EPR
     - Chi-Square test
     - Independence of attributes and goodness of fit
 
-# Text Books:
+# Reference Books
 
 - Joe L Mott, Kandel and Baker, Discrete Mathematics for Computer Scientists
 - J. P. Tremblay and R Manohar Discrete Mathematical Structures with applications to Computer Science, Tata McGraw Hill (2001)
 - Ronald E.Walpole, Raymond H. Myers, Sharon L. Myers, Keying Ye, Probability and Statistics for Engineers and Scientists, 9th Edition, 2012
-
-# Reference Books
-
 - Kolman, Bubby Ross, Discret Mathematics Structures, PHI, 2001
 - C.L. Liu,; Elements of Discrete Mathematics. 1986
 - Gary Haggard, J. Schlipf, S. Whitesides, Discrete Mathematics for Computer Science, Cengage Learning; 2005

--- a/courses/MAIC201.md
+++ b/courses/MAIC201.md
@@ -1,0 +1,116 @@
+---
+code: MAIC201
+title: Discrete Mathematics and Statistical Methods
+
+similar: [MAIR24]
+needs_screening: true
+
+specifics:
+  - branch: CS
+    semester: 3
+    credits: [3, 0, 0, 3]
+
+  - branch: IT
+    semester: 3
+    credits: [3, 0, 0, 3]
+
+  - branch: AI & ML
+    semester: 3
+    credits: [3, 0, 0, 3]
+
+  - branch: PI
+    semester: <semester>
+    credits: [<lecture>, <tutorial>, <practical>, <total>]
+
+prereq: []
+kind: EPR
+---
+
+# Objectives
+
+- To give the students deeper knowledge about Probability and Distributions.
+- To study the topics of discrete mathematics with engineering applications.
+- To apply graph theory based tools in solving practical problems.
+- To impart knowledge about Statictical Methods.
+
+# Content
+
+## Unit 1
+
+1.  **Discrete Probability:**
+    - Basic definitions
+    - Engineering applications of probability
+    - Set theory
+    - Probability Multiplication principle
+    - Product of sums principle
+    - Cross product of sample spaces
+    - Theorem of Total probability
+    - Conditional Probability
+    - Mutual Exclusion and Independent Events
+    - Principle Of Inclusion and Exclusion
+    - Bayes' Rule
+
+## Unit 2
+
+1.  **Discrete Random Variable & Distributions:**
+    - Random variables and their event spaces
+    - Probability Mass function
+    - Distribution function
+    - Mean & Variance of random variables
+    - Expected value of random variable & Computation of expectation for one variable
+    - Bernoulli Trial & Binomial distribution
+    - Poisson distribution
+    - Normal distribution
+    - Recurrence relation and their solutions
+
+## Unit 3
+
+1.  **Graphs:**
+    - Basic Terminology
+    - Multigraphs and Weighted Graphs
+    - Paths and Circuits
+    - Shortest Paths in Weighted Graphs
+    - Eulerian Paths and Circuits
+    - Hamiltonian Paths and Circuits
+    - Planar Graphs
+
+## Unit 4
+
+1.  **Relation and Logic:**
+    - Binary Relation and their properties
+    - Equivalence relations and partitions
+    - Partial ordering relations
+    - Linear ordering relations
+    - Chains
+    - Functions and Pigeonhole principle
+    - Propositions
+
+## Unit 5
+
+1.  **Statistical Methods:**
+    - Large sample tests
+    - Procedure of testing hypothesis
+    - Small sample tests
+    - Student's T-test
+    - Chi-Square test
+    - Independence of attributes and goodness of fit
+
+# Text Books:
+
+- Joe L Mott, Kandel and Baker, Discrete Mathematics for Computer Scientists
+- J. P. Tremblay and R Manohar Discrete Mathematical Structures with applications to Computer Science, Tata McGraw Hill (2001)
+- Ronald E.Walpole, Raymond H. Myers, Sharon L. Myers, Keying Ye, Probability and Statistics for Engineers and Scientists, 9th Edition, 2012
+
+# Reference Books
+
+- Kolman, Bubby Ross, Discret Mathematics Structures, PHI, 2001
+- C.L. Liu,; Elements of Discrete Mathematics. 1986
+- Gary Haggard, J. Schlipf, S. Whitesides, Discrete Mathematics for Computer Science, Cengage Learning; 2005
+
+
+# Outcomes
+
+- To use discrete and continuous probability distribution in practical problems.
+- Use the relations, prepositions, and graph theory in practical engineering.
+- To apply the different testing tools like Student's T-test, Shi-Square test, etc. to analyse the relevant real-life problems.
+- Prove mathematical theorems using mathematical inductions.

--- a/courses/MAIC201.md
+++ b/courses/MAIC201.md
@@ -14,7 +14,7 @@ specifics:
     semester: 3
     credits: [3, 0, 0, 3]
 
-  - branch: AI & ML
+  - branch: AI
     semester: 3
     credits: [3, 0, 0, 3]
 


### PR DESCRIPTION
Created MAIC201. It is actually a new syllabus made this year 2023-24 for CS, IT, AI & ML branches.
It is somewhat similar to old syllabus of MAIR24 but some units and topics are removed or replaced by new topics.
Here i have attached my reference.
![pg1MAIC201](https://github.com/nkss-dev/atlas/assets/116421305/4a16a656-8ed7-4618-92f7-3da11d543f90)
![pg2MAIC201](https://github.com/nkss-dev/atlas/assets/116421305/6cf58751-3a44-41d0-8963-f33d91d10764)
![pg3MAIC201](https://github.com/nkss-dev/atlas/assets/116421305/2c3cf171-ff20-4306-ab29-0c89ae66e9d6)
